### PR TITLE
Handle login with session storage

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,12 +13,30 @@ import "../css/app.scss"
 //     import socket from "./socket"
 //
 import "phoenix_html"
-import {Socket} from "phoenix"
+import { Socket } from "phoenix"
 import NProgress from "nprogress"
-import {LiveSocket} from "phoenix_live_view"
+import { LiveSocket } from "phoenix_live_view"
 
+let Hooks = {};
+Hooks.LoginToken = {
+  mounted() {
+    console.log("Mounted")
+    this.handleEvent("login_token_validated", ({ token }) => {
+      console.log("Event received")
+      var xmlHttpRequest = new XMLHttpRequest();
+      xmlHttpRequest.open("GET", "/session/set_session/" + token, false);
+      xmlHttpRequest.send(null);
+      if (xmlHttpRequest.responseText == "ok") {
+        window.location = "/";
+      }
+      else {
+        alert("Failure");
+      }
+    })
+  }
+}
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfToken }, hooks: Hooks })
 
 // Show progress bar on live navigation and form submits
 window.addEventListener("phx:page-loading-start", info => NProgress.start())

--- a/lib/content_dock/accounts.ex
+++ b/lib/content_dock/accounts.ex
@@ -103,9 +103,12 @@ defmodule ContentDock.Accounts do
   end
 
   def handle_email_login(email, base_url) do
-    case Repo.get_by(User, email: email) do
-      %User{} -> send_login_link(email, base_url)
+    with %User{id: id} <- Repo.get_by(User, email: email),
+         {:ok, token} <- send_login_link(email, base_url) do
+      {:ok, {token, id}}
+    else
       nil -> {:error, :user_not_found}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/content_dock_web/controllers/login_controller.ex
+++ b/lib/content_dock_web/controllers/login_controller.ex
@@ -5,4 +5,17 @@ defmodule ContentDockWeb.Login do
     Phoenix.PubSub.broadcast(ContentDock.PubSub, "login_token:#{token}", {:login_token, token})
     text(conn, "You made it in! Token: #{token}")
   end
+
+  def set_session_user_id(conn, %{"token" => token}) do
+    case Phoenix.Token.verify(ContentDockWeb.Endpoint, "login_token_validated", token, max_age: 15) do
+      {:ok, user_id} ->
+        conn
+        |> put_session(:current_user_id, user_id)
+        |> text("ok")
+
+      {:error, _reason} ->
+        conn
+        |> text("error")
+    end
+  end
 end

--- a/lib/content_dock_web/live/login_live.ex
+++ b/lib/content_dock_web/live/login_live.ex
@@ -3,29 +3,50 @@ defmodule ContentDockWeb.LoginLive do
 
   require Logger
 
-  def mount(_, _session, socket) do
+  def mount(_, session, socket) do
+    socket =
+      socket
+      |> assign(:logging_in, true)
+      |> assign(:current_user_id, session["current_user_id"])
+
     {:ok, socket}
   end
 
   def handle_event("login", %{"login" => %{"email" => email}}, socket) do
-    case ContentDock.Accounts.handle_email_login(email, socket.endpoint.url()) do
-      {:ok, token} ->
-        Phoenix.PubSub.subscribe(ContentDock.PubSub, "login_token:#{token}")
-        {:noreply, assign(socket, :token, token)}
+    socket =
+      case ContentDock.Accounts.handle_email_login(email, socket.endpoint.url()) do
+        {:ok, {token, id}} ->
+          Phoenix.PubSub.subscribe(ContentDock.PubSub, "login_token:#{token}")
 
-      {:error, :user_not_found} ->
-        Logger.warn("Failed login")
-        {:noreply, socket}
-    end
+          socket
+          |> assign(:token, token)
+          |> assign(:user_id, id)
+
+        {:error, :user_not_found} ->
+          Logger.warn("Failed login")
+          socket
+      end
+
+    {:noreply, assign(socket, :logging_in, false)}
   end
 
   def handle_info({:login_token, token}, socket) do
-    if socket.assigns.token && socket.assigns.token == token do
-      Logger.info("Successfully logged in")
-    else
-      Logger.warn("WRONG TOKEN FOOL")
-    end
+    socket =
+      if socket.assigns.token && socket.assigns.token == token do
+        Logger.info("Successfully logged in")
+        set_session_user_id(socket)
+      else
+        Logger.warn("WRONG TOKEN FOOL")
+        socket
+      end
 
     {:noreply, socket}
+  end
+
+  def set_session_user_id(socket) do
+    token =
+      Phoenix.Token.sign(ContentDockWeb.Endpoint, "login_token_validated", socket.assigns.user_id)
+
+    push_event(socket, "login_token_validated", %{token: token})
   end
 end

--- a/lib/content_dock_web/live/login_live.html.leex
+++ b/lib/content_dock_web/live/login_live.html.leex
@@ -1,4 +1,11 @@
-<%= form_for :login, "#" , [phx_submit: :login], fn f -> %>
+<%= if @logging_in do %>
+  <%= form_for :login, "#" , [phx_submit: :login], fn f -> %>
   <%= text_input f, :email, placeholder: "Email" %>
   <%= submit "Login" %>
 <% end %>
+<% else %>
+  <h3>If your email was found in our system, a message has been sent with a login link.</h3>
+  <p>Please keep this window open and you will be redirected</p>
+<% end %>
+<div id="login-token-hook" phx-hook="LoginToken"></div>
+<%= @current_user_id %>

--- a/lib/content_dock_web/router.ex
+++ b/lib/content_dock_web/router.ex
@@ -9,7 +9,7 @@ defmodule ContentDockWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
 
-    # Plug - set current user from user in the assign if present. .... if user_id in session, current_user = user from database
+    # Plug (AssignCurrentUser) - set current user from User%{} from DB in the assign if present. .... if user_id in session, current_user = user from database
   end
 
   pipeline :api do
@@ -37,6 +37,7 @@ defmodule ContentDockWeb.Router do
     # Work on this
     # Create controller that takes this and broadcasts token over PubSub
     get "/token/:token", Login, :submit_token
+    get "/set_session/:token", Login, :set_session_user_id
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
Add current user to session without reloading the live view so we
know the currently logged in user everywhere, without losing the
current state of the live view