### PR TITLE
Only import module

### DIFF
--- a/lib/content_dock_web/plugs/assign_current_user.ex
+++ b/lib/content_dock_web/plugs/assign_current_user.ex
@@ -5,13 +5,12 @@ defmodule ContentDockWeb.Plugs.AssignCurrentUser do
   import Plug.Conn
 
   alias ContentDock.Accounts
-  alias Plug.Conn
 
   @preloads [:roles]
 
   def init(opts), do: opts
 
-  def call(%Conn{} = conn, _opts) do
+  def call(conn, _opts) do
     case get_session(conn, :current_user_id) do
       nil -> assign(conn, :current_user, nil)
       current_user_id -> assign(conn, :current_user, Accounts.get_user(current_user_id, @preloads))


### PR DESCRIPTION
Import `Plug.Conn` instead of importing and aliasing to reduce
redundancy